### PR TITLE
ch1 ex3: Fix variable naming to be consistent

### DIFF
--- a/examples/chapter 1 - basics/ex 1 3 aggregates.cpp
+++ b/examples/chapter 1 - basics/ex 1 3 aggregates.cpp
@@ -18,7 +18,7 @@ int main() {
     int nums[10] { 1 }; // 1, and then all 0s
 
     // structures:
-    Line longLone {0, 0, 100, 100};
+    Line longLine {0, 0, 100, 100};
     Line anotherLine = {100}; // rest set to 0
     Line shortLine {{-10, -10}, {10, 10}}; // nested
 }


### PR DESCRIPTION
A minor typo in the `Line` variables.